### PR TITLE
fix(ci): add missing bcrypt/PyJWT/paramiko hidden imports for web builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -533,7 +533,7 @@ jobs:
       - name: 安装依赖
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          pip install nicegui requests pyinstaller
+          pip install nicegui requests bcrypt PyJWT paramiko pyinstaller
       - name: 下载 UPX
         run: |
           Invoke-WebRequest -Uri "https://github.com/upx/upx/releases/download/v4.2.4/upx-4.2.4-win64.zip" -OutFile upx.zip
@@ -552,6 +552,7 @@ jobs:
             --hidden-import starlette --hidden-import fastapi `
             --hidden-import httptools --hidden-import websockets `
             --hidden-import requests --hidden-import urllib3 --hidden-import certifi `
+            --hidden-import bcrypt --hidden-import jwt --hidden-import paramiko `
             --collect-data nicegui --collect-submodules nicegui `
             --exclude-module torch --exclude-module tensorflow `
             --exclude-module scipy --exclude-module matplotlib `
@@ -591,7 +592,7 @@ jobs:
       - name: 安装依赖
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          pip install nicegui requests pyinstaller
+          pip install nicegui requests bcrypt PyJWT paramiko pyinstaller
       - name: PyInstaller 打包
         run: |
           pyinstaller \
@@ -605,6 +606,7 @@ jobs:
             --hidden-import=starlette --hidden-import=fastapi \
             --hidden-import=httptools --hidden-import=websockets \
             --hidden-import=requests --hidden-import=urllib3 --hidden-import=certifi \
+            --hidden-import=bcrypt --hidden-import=jwt --hidden-import=paramiko \
             --collect-data nicegui --collect-submodules nicegui \
             --exclude-module torch --exclude-module tensorflow \
             --exclude-module scipy --exclude-module matplotlib \
@@ -647,7 +649,7 @@ jobs:
       - name: 安装 Python 依赖
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          pip install nicegui requests pyinstaller
+          pip install nicegui requests bcrypt PyJWT paramiko pyinstaller
       - name: PyInstaller 打包
         run: |
           pyinstaller \


### PR DESCRIPTION
## 问题

Web 构建的 exe 启动时报错：\ModuleNotFoundError: No module named 'bcrypt'\

原因是 \uild.yml\ 中 Web 版 PyInstaller 打包时缺少 \--hidden-import bcrypt\ 和 \--hidden-import jwt\，且 pip 安装依赖时也未安装 \crypt\ 和 \PyJWT\。

## 修复

1. pip install 添加 \crypt\、\PyJWT\、\paramiko\
2. PyInstaller 命令添加 \--hidden-import bcrypt\、\--hidden-import jwt\、\--hidden-import paramiko\
3. 同步修复了 macOS 和 Linux 的 Web 构建

适用于 \uild-web-windows\、\uild-web-macos\、\uild-web-linux\ 三个 Job。